### PR TITLE
A fix and a couple of improvement suggestions

### DIFF
--- a/AzuriteExplorer.ps1
+++ b/AzuriteExplorer.ps1
@@ -51,8 +51,16 @@ Email: apostolis.mastoris[at]mwrinfosecurity.com
     # This is the secure option and most preferred.
     Login-AzureRmAccount
 
-    # Pring information for the Azure subscriptions available for the user.
-    Get-AzureRmSubscription
+    # Ask for an (optional) TenantId
+    $tenantId = Read-Host "Please provide a Tenant Id to perform the review (blank to leave to default)"
+
+    # Pring information for the Azure subscriptions available for the user
+    Write-Host "Tenant-Id:" $tenantId
+    if ($tenantID) {
+      Get-AzureRmSubscription -TenantId $tenantId
+    } else {
+      Get-AzureRmSubscription
+    }
 
     # Request from the user to input the corresponding subscription Id to use during the review.
     $subscriptionId = Read-Host "Please provide the Subscription Id of the subscription to perform the review"

--- a/AzuriteExplorer.ps1
+++ b/AzuriteExplorer.ps1
@@ -269,6 +269,9 @@ Email: apostolis.mastoris[at]mwrinfosecurity.com
         [System.IO.File]::W‌​riteAllLines($azureSubscriptionConfigurationFilePath, $azureSubscriptionConfigurationContent, $Utf8NoBomEncoding)
         #>
 
+        # finally create a json file with all resources (as not all resource types are handled in a greater level of detail)
+        Get-AzureRmResource | ConvertTo-Json -Depth 10 | Out-File $(".\azure-cmdb_" + $subscriptionId + "_" + $context.Account +  ".json") -Encoding UTF8
+
         # Present information/statistics about the Azure subscription. 
         Write-Host "[*] Azure Subscription Information - Subscription Id $subscriptionId"
         Write-Host "    [-] Resource Groups: $($resourceGroups.Count)"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Import the AzureRM module:
 Import Azurite Explorer module in PowerShell and retrieve the information for an Azure subscription. 
 
     # PS> Import-Module AzuriteExplorer.ps1
-    # PS> Review-CustomAzureRmSubscription
+    # PS> Review-AzureRmSubscription
 
 Provide credentials for the Azure subscription under review. The user should belong to one of the following roles:
 * Owner


### PR DESCRIPTION
I started using Azurite to introspect subscriptions and wanted to suggest a few changes:
- tenant-id as parameter to make work in an environment with lots of subscriptions in different tenants
- add a generic dump (cmdb) of all resources, aiming at getting a complete overview of all ARM resources, even with less level of detail